### PR TITLE
fix: tap rest api refresh feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ poetry run hub-utils --help
 ```bash
 poetry run pytest -v
 
-poetry run pytest -v tests/test_core.py::test_sdk_about_parsing_1
+poetry run pytest -v tests/test_meltano_utils.py::test_sdk_about_parsing_1
 ```
 
 **Refreshing This README**

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -58,7 +58,7 @@ def callback():
     ```bash
     poetry run pytest -v
 
-    poetry run pytest -v tests/test_core.py::test_sdk_about_parsing_1
+    poetry run pytest -v tests/test_meltano_utils.py::test_sdk_about_parsing_1
     ```
 
     **Refreshing This README**

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -227,7 +227,10 @@ class MeltanoUtil:
             if name in reformatted_settings_2:
                 existing_setting = reformatted_settings_2.get(name)
                 existing_setting["description"] = ", ".join(
-                    [existing_setting["description"], MeltanoUtil._clean_description(setting.get("description"))]
+                    [
+                        existing_setting["description"],
+                        MeltanoUtil._clean_description(setting.get("description")),
+                    ]
                 )
             else:
                 reformatted_settings_2[name] = setting
@@ -275,7 +278,7 @@ class MeltanoUtil:
             description = MeltanoUtil._handle_description(
                 MeltanoUtil._clean_description(settings.get("description")),
                 name,
-                enforce_desc
+                enforce_desc,
             )
             setting_details = {
                 "name": name,
@@ -317,7 +320,9 @@ class MeltanoUtil:
                     reqs = value.get("required", [])
                     field = {
                         "name": full_name,
-                        "description": MeltanoUtil._clean_description(subfield.get("description")),
+                        "description": MeltanoUtil._clean_description(
+                            subfield.get("description")
+                        ),
                         "default": subfield.get("default"),
                         "type": subfield.get("type"),
                         "title": subfield.get("title"),
@@ -336,7 +341,9 @@ class MeltanoUtil:
                 fields.append(
                     {
                         "name": key,
-                        "description": MeltanoUtil._clean_description(value.get("description")),
+                        "description": MeltanoUtil._clean_description(
+                            value.get("description")
+                        ),
                         "default": value.get("default"),
                         "type": value.get("type"),
                         "title": value.get("title"),
@@ -378,7 +385,9 @@ class MeltanoUtil:
         desc_list_clean = []
         for word in word_list:
             if len(word.split(".")) > 1:
-                if not any(keyword in word for keyword in ("http", "ssh", "ssl", "e.g.")):
+                if not any(
+                    keyword in word for keyword in ("http", "ssh", "ssl", "e.g.")
+                ):
                     desc_list_clean.extend(word.replace(".", ". ").split())
                     continue
             desc_list_clean.append(word)
@@ -398,12 +407,17 @@ class MeltanoUtil:
         for elem in capital_list:
             sentence_list = elem.split()
             last_elem = MeltanoUtil._last_element(clean_capital_list)
-            if sentence_list[0][0].isupper() or sentence_list[0][0] == "'" or last_elem.endswith('e.g') or last_elem.endswith('i.e'):
+            if (
+                sentence_list[0][0].isupper()
+                or sentence_list[0][0] == "'"
+                or last_elem.endswith("e.g")
+                or last_elem.endswith("i.e")
+            ):
                 clean_capital_list.append(" ".join(sentence_list))
             else:
                 sentence_list[0] = sentence_list[0].capitalize()
                 clean_capital_list.append(" ".join(sentence_list))
-            
+
         return ". ".join(clean_capital_list)
 
     @staticmethod

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -365,7 +365,8 @@ class MeltanoUtil:
         for word in word_list:
             if len(word.split(".")) > 1:
                 if not any(
-                    keyword in word for keyword in ("http", "ssh", "ssl", "e.g.", '"', "`")
+                    keyword in word
+                    for keyword in ("http", "ssh", "ssl", "e.g.", '"', "`")
                 ):
                     desc_list_clean.extend(word.replace(".", ". ").split())
                     continue

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -398,7 +398,7 @@ class MeltanoUtil:
         for elem in capital_list:
             sentence_list = elem.split()
             last_elem = MeltanoUtil._last_element(clean_capital_list)
-            if sentence_list[0][0].isupper() or last_elem.endswith('e.g') or last_elem.endswith('i.e'):
+            if sentence_list[0][0].isupper() or sentence_list[0][0] == "'" or last_elem.endswith('e.g') or last_elem.endswith('i.e'):
                 clean_capital_list.append(" ".join(sentence_list))
             else:
                 sentence_list[0] = sentence_list[0].capitalize()
@@ -416,46 +416,3 @@ class MeltanoUtil:
         cleaned_sentence = MeltanoUtil._split_sentence_endings(desc_list)
         cleaned_description = MeltanoUtil._capitalize(cleaned_sentence)
         return cleaned_description
-    
-        # desc_list_clean = [elem for elem in ]
-        description = description.replace(".", ". ")
-
-
-
-        # Upper case the first letter of the description in each sentence
-        description = MeltanoUtil._upper_case_first_letter(description)
-
-
-
-
-        # Split the description by periods and commas, and preserve them in the result
-        split_description = description.split()
-        split_description = [
-            elem.replace(".", ". ").replace(",", ", ")
-            if not any(keyword in elem for keyword in ("http", "ssh", "ssl", "e.g."))
-            else elem
-            for elem in split_description
-        ]
-        split_description = " ".join(split_description).split()
-
-        # Capitalize the first word of each sentence
-        for i in range(len(split_description)):
-            if i == 0 or (
-                i > 0
-                and (
-                    split_description[i - 1].endswith(".")
-                )
-            ):
-                if not split_description[i][0].isupper():
-                    split_description[i] = split_description[i].capitalize()
-
-        # Join the cleaned description back into a single string
-        cleaned_description = " ".join(split_description)
-
-        return cleaned_description
-
-
-if __name__ == "__main__":
-    MeltanoUtil()._clean_description("By providing a path-like prefix (e.g. myFolder/thisTable/) under which all the relevant files sit, we.")
-    # MeltanoUtil()._clean_description("a sentence.with bad punctuation.Starts here. with another sentence. Being poorly written. checkout this link <a href=\"https://json-schema.org/understanding-json-schema/reference/type.html\" target=\"_blank\">JSON Schema datatypes</a>.")
-    # MeltanoUtil()._clean_description("Optionally provide a schema to enforce, as a valid JSON string. Ensure this is a mapping of <strong>{ \"column\" : \"type\" }</strong>, where types are valid <a href=\"https://json-schema.org/understanding-json-schema/reference/type.html\" target=\"_blank\">JSON Schema datatypes</a>. Leave as {} to auto-infer the schema.")

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -288,7 +288,7 @@ class MeltanoUtil:
             setting_details["kind"] = kind
             if options:
                 setting_details["options"] = options
-            if settings.get("default"):
+            if settings.get("default") is not None:
                 if kind != "date_iso8601":
                     setting_details["value"] = settings.get("default")
             reformatted_settings.append(setting_details)

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -359,34 +359,13 @@ class MeltanoUtil:
                 fields.append(i)
         return fields
 
-    # @staticmethod
-    # def _process_words(word_list, desc_list_clean, capitalize_next):
-    #     for word in word_list:
-    #         if capitalize_next:
-    #             word = word.capitalize()
-    #             capitalize_next = False
-    #         if "." in word:
-    #             # Its at the end
-    #             if word.endswith("."):
-    #                 # Add a space after
-    #                 word = word + " "
-    #                 # index + 1 capitalize
-    #                 capitalize_next = True
-    #                 desc_list_clean.append(word)
-    #             else:
-    #                 word_list = word.split(".")
-    #                 MeltanoUtil._process_words(word_list, desc_list_clean, False)
-    #         else:
-    #             desc_list_clean.append(word)
-    #     return desc_list_clean
-
     @staticmethod
     def _split_sentence_endings(word_list):
         desc_list_clean = []
         for word in word_list:
             if len(word.split(".")) > 1:
                 if not any(
-                    keyword in word for keyword in ("http", "ssh", "ssl", "e.g.")
+                    keyword in word for keyword in ("http", "ssh", "ssl", "e.g.", '"', "`")
                 ):
                     desc_list_clean.extend(word.replace(".", ". ").split())
                     continue

--- a/hub_utils/utilities.py
+++ b/hub_utils/utilities.py
@@ -495,27 +495,6 @@ class Utilities:
         ]
 
     @staticmethod
-    def _clean_description(description):
-        # Split the description by periods and commas, and preserve them in the result
-        split_description = description.replace(".", ". ").replace(",", ", ").split()
-
-        # Capitalize the first word of each sentence
-        for i in range(len(split_description)):
-            if i == 0 or (
-                i > 0
-                and (
-                    split_description[i - 1].endswith(".")
-                    or split_description[i - 1].endswith(",")
-                )
-            ):
-                split_description[i] = split_description[i].capitalize()
-
-        # Join the cleaned description back into a single string
-        cleaned_description = " ".join(split_description)
-
-        return cleaned_description
-
-    @staticmethod
     def _merge_settings(existing_settings, settings):
         new_settings = []
         name_lookup = {setting.get("name"): setting for setting in settings}
@@ -533,7 +512,7 @@ class Utilities:
                 # then its probably a custom/manual override so keep it.
                 setting["description"] = existing_desc
             else:
-                setting["description"] = Utilities._clean_description(
+                setting["description"] = MeltanoUtil._clean_description(
                     setting["description"]
                 )
             # TODO: if existing is much longer we might want to keep it

--- a/hub_utils/utilities.py
+++ b/hub_utils/utilities.py
@@ -495,6 +495,27 @@ class Utilities:
         ]
 
     @staticmethod
+    def _clean_description(description):
+        # Split the description by periods and commas, and preserve them in the result
+        split_description = description.replace(".", ". ").replace(",", ", ").split()
+
+        # Capitalize the first word of each sentence
+        for i in range(len(split_description)):
+            if i == 0 or (
+                i > 0
+                and (
+                    split_description[i - 1].endswith(".")
+                    or split_description[i - 1].endswith(",")
+                )
+            ):
+                split_description[i] = split_description[i].capitalize()
+
+        # Join the cleaned description back into a single string
+        cleaned_description = " ".join(split_description)
+
+        return cleaned_description
+
+    @staticmethod
     def _merge_settings(existing_settings, settings):
         new_settings = []
         name_lookup = {setting.get("name"): setting for setting in settings}
@@ -511,6 +532,10 @@ class Utilities:
                 # If the existing description is longer and has new line characters
                 # then its probably a custom/manual override so keep it.
                 setting["description"] = existing_desc
+            else:
+                setting["description"] = Utilities._clean_description(
+                    setting["description"]
+                )
             # TODO: if existing is much longer we might want to keep it
             existing_value = name_lookup_existing.get(name, {}).get("value", "")
             if str(existing_value).startswith("$MELTANO"):

--- a/tests/test_meltano_utils.py
+++ b/tests/test_meltano_utils.py
@@ -209,13 +209,15 @@ def test_sdk_about_parsing_airbyte():
             "name": "connector_config.provider.path_prefix",
             "label": "Connector Config Provider Path Prefix",
             "description": "By providing a path-like prefix (e.g. myFolder/thisTable/) under which all the relevant files sit, we can optimize finding these in S3. This is optional but recommended if your bucket contains many folders/files which you don't need to replicate.",
-            "kind": "password"
+            "kind": "password",
+            "value": ""
         },
         {
             "name": "connector_config.provider.endpoint",
             "label": "Connector Config Provider Endpoint",
             "description": "Endpoint to an S3 compatible service. Leave empty to use AWS.",
-            "kind": "password"
+            "kind": "password",
+            "value": ""
         },
         {
             "name": "stream_maps",
@@ -243,7 +245,7 @@ def test_sdk_about_parsing_airbyte():
         }
     ]
     for i, setting in enumerate(settings):
-        assert setting == expected_settings[i]
+        assert setting == expected_settings[i], setting
     assert set(settings_group_validation[0]) == set(
         [
             "airbyte_spec.image",

--- a/tests/test_meltano_utils.py
+++ b/tests/test_meltano_utils.py
@@ -126,7 +126,7 @@ def test_sdk_about_parsing_airbyte():
 
     settings, settings_group_validation, capabilities = MeltanoUtil._parse_sdk_about_settings(sdk_about_dict)
     print(json.dumps(settings))
-    assert settings == [
+    expected_settings = [
         {
             "name": "airbyte_spec.image",
             "label": "Airbyte Spec Image",
@@ -156,7 +156,7 @@ def test_sdk_about_parsing_airbyte():
         {
             "name": "connector_config.format.filetype",
             "label": "Connector Config Format Filetype",
-            "description": "csv, parquet",
+            "description": "Csv, Parquet",
             "kind": "string"
         },
         {
@@ -242,6 +242,8 @@ def test_sdk_about_parsing_airbyte():
             "kind": "integer"
         }
     ]
+    for i, setting in enumerate(settings):
+        assert setting == expected_settings[i]
     assert set(settings_group_validation[0]) == set(
         [
             "airbyte_spec.image",
@@ -356,7 +358,7 @@ def test_sdk_about_parsing_default():
         {
             "name": "test",
             "label": "Test",
-            "description": "my description",
+            "description": "My description",
             "kind": "string",
             "value": "my default"
         }
@@ -384,7 +386,7 @@ def test_sdk_about_parsing_default_bool():
         {
             "name": "test",
             "label": "Test",
-            "description": "my description",
+            "description": "My description",
             "kind": "string",
             "value": False
         }

--- a/tests/test_meltano_utils.py
+++ b/tests/test_meltano_utils.py
@@ -363,6 +363,34 @@ def test_sdk_about_parsing_default():
     ]
 
 
+def test_sdk_about_parsing_default_bool():
+    input = {
+        "settings": {
+            "type": "object",
+            "properties": {
+                "test": {
+                    "type": [
+                        "string"
+                    ],
+                    "default": False,
+                    "description": "my description"
+                }
+            },
+            "required": []
+        }
+    }
+    settings, _, _ = MeltanoUtil._parse_sdk_about_settings(input)
+    assert settings == [
+        {
+            "name": "test",
+            "label": "Test",
+            "description": "my description",
+            "kind": "string",
+            "value": False
+        }
+    ]
+
+
 def test_sdk_about_parsing_skip_default_dates():
     input = {
         "settings": {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -225,6 +225,32 @@ def test_merge_and_update(patch):
                 }
             ],
         ],
+        [
+            [
+                {
+                    "name": "add_metadata_columns",
+                    "description": "Nothing really",
+                    "label": "Add Metadata Columns",
+                    "kind": "boolean",
+                }
+            ],
+            [
+                {
+                    "name": "add_metadata_columns",
+                    "description": "the tap description.With some formatting issues. this one too.also this one.",
+                    "label": "Add Metadata Columns",
+                    "kind": "boolean",
+                }
+            ],
+            [
+                {
+                    "name": "add_metadata_columns",
+                    "description": "The tap description. With some formatting issues. This one too. Also this one.",
+                    "label": "Add Metadata Columns",
+                    "kind": "boolean",
+                }
+            ],
+        ],
     ],
 )
 def test_merge_settings(existing, new, expected):


### PR DESCRIPTION
- Settings defaults were being skipped if they were falsey values like `False` or an empty list of dict. Thats fixed now
- An attempt to clean up some of the descriptions provided by the tap due to the formatting of writing text in the tap.py class.

>I wonder if the script can have a few smarts added to it to add a space if necessarily i.e. where there are concatenated lines and there isn't a trailing or leading space? I also wonder if it could capitalize the first letter in the descriptions? I saw a few examples where the first letter was not a capital. It isn't always obvious when writing a tap how it will look formatted - clearly something for me to check in more detail in the future.